### PR TITLE
Method "public void write(String str, int off, int len)" of "org.spri…

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriter.java
@@ -33,6 +33,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  *
  * @author Dave Syer
  * @author Michael Minella
+ * @author Niels Ferguson
  *
  */
 public class TransactionAwareBufferedWriter extends Writer {
@@ -244,6 +245,6 @@ public class TransactionAwareBufferedWriter extends Writer {
 		}
 
 		StringBuilder buffer = getCurrentBuffer();
-		buffer.append(str, off, len);
+		buffer.append(str, off, off + len);
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriterTests.java
@@ -349,7 +349,7 @@ public class TransactionAwareBufferedWriterTests {
 			try {
 				writer.write("foo", 2, 1);
 			} catch (IOException e) {
-				e.printStackTrace();
+				throw new IllegalStateException("Unexpected IOException", e);
 			}
 			return null;
 		});

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriterTests.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.when;
  * @author Dave Syer
  * @author Michael Minella
  * @author Will Schipp
+ * @author Niels Ferguson
  * 
  */
 public class TransactionAwareBufferedWriterTests {
@@ -335,6 +336,27 @@ public class TransactionAwareBufferedWriterTests {
 		for(int i=0; i< limit; i++) {
 			assertEquals(String.valueOf(i), results[i]);
 		}				
+	}
+
+	//BATCH-3745
+	@Test
+	public void testWriteInTransactionWithOffset() throws IOException{
+		ArgumentCaptor<ByteBuffer> bb = ArgumentCaptor.forClass(ByteBuffer.class);
+		when(fileChannel.write(bb.capture())).thenReturn(1);
+
+		new TransactionTemplate(transactionManager).execute((TransactionCallback<Void>) status -> {
+
+			try {
+				writer.write("foo", 2, 1);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			return null;
+		});
+
+		String s = getStringFromByteBuffer(bb.getValue());
+
+		assertEquals("o", s);
 	}
 
 	private String getStringFromByteBuffer(ByteBuffer bb) {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriterTests.java
@@ -342,12 +342,12 @@ public class TransactionAwareBufferedWriterTests {
 	@Test
 	public void testWriteInTransactionWithOffset() throws IOException{
 		ArgumentCaptor<ByteBuffer> bb = ArgumentCaptor.forClass(ByteBuffer.class);
-		when(fileChannel.write(bb.capture())).thenReturn(1);
+		when(fileChannel.write(bb.capture())).thenReturn(3);
 
 		new TransactionTemplate(transactionManager).execute((TransactionCallback<Void>) status -> {
 
 			try {
-				writer.write("foo", 2, 1);
+				writer.write("hamburger", 4, 3);
 			} catch (IOException e) {
 				throw new IllegalStateException("Unexpected IOException", e);
 			}
@@ -356,7 +356,7 @@ public class TransactionAwareBufferedWriterTests {
 
 		String s = getStringFromByteBuffer(bb.getValue());
 
-		assertEquals("o", s);
+		assertEquals("urg", s);
 	}
 
 	private String getStringFromByteBuffer(ByteBuffer bb) {


### PR DESCRIPTION
…ngframework.batch.support.transaction.TransactionAwareBufferedWriter" now calls "StringBuilder.append(CharSequence, int, int)" correct when for cases where offset > 0.

Unittest added for this case.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `master` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-batch/blob/master/CONTRIBUTING.md